### PR TITLE
Touch up Markdown in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PyInit
 
-This is a simple extension that generates __init__.py files inside your folders and subfolders.
+This is a simple extension that generates `__init__.py` files inside your folders and subfolders.
 
 ## Functionality
 
-When in a folder, right click and select "Generate init file" or use the keybinding crtl+i or cmd+i (mac users). The extension will generate __init__.py files recursively inside the selected folder and its subfolders.
+When in a folder, right click and select "Generate init file" or use the keybinding crtl+i or cmd+i (mac users). The extension will generate `__init__.py` files recursively inside the selected folder and its subfolders.
 
 ![PiInit Example](images/piinit.gif)


### PR DESCRIPTION
Otherwise `__init__.py` shows up as **init**.py when rendered.